### PR TITLE
Speed up PR checks

### DIFF
--- a/delete-old-branches
+++ b/delete-old-branches
@@ -85,15 +85,9 @@ is_pr_open_on_branch() {
     fi
 
     local br=${1}
-    open_prs_branches=$(gh api "repos/${REPO}/pulls" --jq '.[].head.ref' --paginate)
-
-    for pr_br in ${open_prs_branches}; do
-      if [[ "${pr_br}" == "${br}" ]]; then
-          return 0
-      fi
-    done
-
-    return 1
+    # Check against cached open PR branches instead of making API calls
+    echo "${OPEN_PR_BRANCHES}" | grep -qx "${br}"
+    return $?
 }
 
 delete_branch_or_tag() {
@@ -133,6 +127,17 @@ main() {
         echo "Re-fetching without --unshallow..."
         git fetch --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
     fi
+
+    # Fetch all open PR branches once
+    echo "Fetching open PR branches..."
+    if [[ "${EXCLUDE_OPEN_PR_BRANCHES}" == true ]]; then
+        OPEN_PR_BRANCHES=$(gh api "repos/${REPO}/pulls" --jq '.[].head.ref' --paginate)
+        local pr_count=$(echo "${OPEN_PR_BRANCHES}" | grep -c '^' || echo 0)
+        echo "Found ${pr_count} branches with open PRs"
+    else
+        OPEN_PR_BRANCHES=""
+    fi
+
     echo "Checking branches..."
     for br in $(git ls-remote -q --heads --refs | sed "s@^.*heads/@@"); do
 


### PR DESCRIPTION
## Problem:
- The is_pr_open_on_branch() function was making a GitHub API call for every branch being checked (~1,000+ branches)
- Each API call took ~5 seconds, resulting in 83+ minutes total runtime
- This exceeded the 30-minute GitHub Actions timeout limit

## Solution:
- Fetch all open PR branches once at the start of main() function
- Cache the results in OPEN_PR_BRANCHES variable
- Modified is_pr_open_on_branch() to check against cached list using grep
- Reduced API calls from 1,000+ to just 1

## Expected Impact:
- Runtime reduction: 30+ minutes → 2-5 minutes
- Eliminates redundant API calls
- Workflow will now complete within timeout limits
