### PR TITLE
perf: optimize git fetch to avoid timeout on large repos

### DIFF
--- a/delete-old-branches
+++ b/delete-old-branches
@@ -121,11 +121,17 @@ main() {
     git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
     # catch error for git fetch with --unshallow if complete repo clone
-    if ! git fetch --prune --unshallow --tags origin '+refs/heads/*:refs/remotes/origin/*'; then
-        echo "Error: Failed to fetch branches and tags. This is likely because the repository is a complete clone."
+    if ! git fetch --prune --unshallow --no-tags origin '+refs/heads/*:refs/remotes/origin/*'; then
+        echo "Error: Failed to fetch branches with --unshallow. This is likely because the repository is a complete clone."
 
-        echo "Re-fetching without --unshallow..."
-        git fetch --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
+        echo "Re-fetching without --unshallow and without tags for speed..."
+        git fetch --prune --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+    fi
+
+    # Only fetch tags if we need them for tag deletion
+    if [[ "${DELETE_TAGS}" == true ]]; then
+        echo "Fetching tags (required for tag deletion)..."
+        git fetch --prune --tags origin
     fi
 
     # Fetch all open PR branches once


### PR DESCRIPTION
## Purpose
Fix the 30-minute timeout issue occurring when the action runs on large repositories like betterup-monolith. The timeout was caused by unnecessarily fetching all tags during branch cleanup operations.

## Context
When the initial `git fetch --unshallow --tags` fails (due to git corruption or other errors), the retry logic was still attempting to fetch all tags. For large repositories with many tags, this causes a massive data transfer that exceeds the GitHub Actions 30-minute timeout limit.

The logs showed:
- Initial fetch failing with git corruption: "error: inflate: stream consistency error"
- Retry fetch running for over 20 minutes before timeout
- Action cancelled at 30-minute mark without completing

## Changes
Modified the `delete-old-branches` script to:
1. Use `--no-tags` flag in both initial and retry fetch operations
2. Only fetch tags conditionally when `DELETE_TAGS=true`
3. Improved error messages to clarify retry behavior

This optimization is safe because:
- Tags are only needed when the action is configured to delete tags
- Branch deletion only requires branch refs, not tag refs
- Backward compatibility is maintained - tag deletion still works when enabled

## Guidance
👀

## Artifacts
- Related to timeout logs in: `./logs/delete-stale-branches-logs_50605624249/0_delete-stale-branches.txt`
- Follows up on performance improvements from #2