### PR TITLE
fix: prevent spurious empty batch when branch count is an exact multiple of batch size

### DIFF
--- a/build-matrix
+++ b/build-matrix
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# build-matrix: Read a newline-delimited branch list from stdin, split into
+# batches, and emit a GitHub Actions strategy matrix JSON.
+#
+# Usage:
+#   echo "$branch_list" | build-matrix [--batch-size N]
+#   build-matrix --batch-size 50 < branches.txt
+#
+# Output:
+#   Writes `matrix=<json>` to $GITHUB_OUTPUT (if set), and always prints
+#   the matrix JSON + a human-readable summary to stdout.
+#
+# Exit codes:
+#   0  success
+
+set -eo pipefail
+
+BATCH_SIZE=100
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --batch-size)
+            BATCH_SIZE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Read branch list from stdin, stripping blank lines and trailing whitespace
+branches=$(sed '/^[[:space:]]*$/d' | sed 's/[[:space:]]*$//')
+
+filtered_count=$(printf '%s\n' "$branches" | grep -c '.' || true)
+
+echo ""
+echo "====== BATCH SUMMARY ======"
+echo "Branches to batch: ${filtered_count}"
+
+if [[ ${filtered_count} -eq 0 ]]; then
+    echo "No branches to process. Creating empty matrix."
+    matrix_json='{"include":[]}'
+
+    if [[ -n "${GITHUB_OUTPUT}" ]]; then
+        echo "matrix=${matrix_json}" >> "$GITHUB_OUTPUT"
+    fi
+
+    echo ""
+    echo "====== BUILD MATRIX COMPLETE ======"
+    echo "Total batches: 0"
+    echo "Matrix JSON (pretty):"
+    echo "$matrix_json" | jq .
+    exit 0
+fi
+
+num_batches=$(( (filtered_count + BATCH_SIZE - 1) / BATCH_SIZE ))
+echo "Will create ${num_batches} batches of up to ${BATCH_SIZE} branches each"
+
+# Split into batch files using printf to avoid adding extra trailing newlines
+matrix_include='[]'
+batch_num=0
+
+printf '%s\n' "$branches" | split -l "${BATCH_SIZE}" - _batch_
+
+for batch_file in _batch_*; do
+    batch_branches=$(tr '\n' ' ' < "$batch_file" | sed 's/ $//')
+    branch_count=$(grep -c '.' "$batch_file" || true)
+
+    # Skip empty batch files (defensive guard)
+    if [[ ${branch_count} -eq 0 ]]; then
+        rm "$batch_file"
+        continue
+    fi
+
+    batch_json=$(jq -n \
+        --arg batch "$batch_num" \
+        --arg branches "$batch_branches" \
+        --arg count "$branch_count" \
+        '{batch: $batch, branches: $branches, count: ($count | tonumber)}')
+
+    matrix_include=$(echo "$matrix_include" | jq --argjson item "$batch_json" '. += [$item]')
+
+    echo "Batch ${batch_num}: ${branch_count} branches"
+    batch_num=$((batch_num + 1))
+    rm "$batch_file"
+done
+
+matrix_json=$(jq -nc --argjson include "$matrix_include" '{include: $include}')
+
+if [[ -n "${GITHUB_OUTPUT}" ]]; then
+    echo "matrix=${matrix_json}" >> "$GITHUB_OUTPUT"
+fi
+
+echo ""
+echo "====== BUILD MATRIX COMPLETE ======"
+echo "Total batches: ${batch_num}"
+echo "Matrix JSON (pretty):"
+echo "$matrix_json" | jq .

--- a/discover-branches
+++ b/discover-branches
@@ -105,63 +105,12 @@ echo "  - Default branches: ${default_branch_count}"
 echo "  - Regex-protected branches: ${regex_protected_count}"
 echo "  - Branches with open PRs: ${pr_branch_count}"
 echo "Remaining branches to process: ${filtered_count}"
-echo ""
 
-# Check if there are any branches left to process
-if [[ ${filtered_count} -eq 0 ]]; then
-    echo "No branches to process after filtering. Creating empty matrix."
-    matrix_json='{"include":[]}'
-    echo "matrix=${matrix_json}" >> "$GITHUB_OUTPUT"
-    echo ""
-    echo "====== DISCOVERY COMPLETE ======"
-    echo "Total branches found: ${total_branches}"
-    echo "Branches after filtering: ${filtered_count}"
-    echo "Total batches: 0"
-    exit 0
-fi
-
-# Calculate number of batches needed based on filtered count
-num_batches=$(( (filtered_count + BATCH_SIZE - 1) / BATCH_SIZE ))
-echo "Will create ${num_batches} batches of up to ${BATCH_SIZE} branches each"
-
-# Create batches and build matrix JSON
-matrix_include='[]'
-batch_num=0
-
-printf '%s' "$branches" | split -l "${BATCH_SIZE}" - batch_
-for batch_file in batch_*; do
-    batch_branches=$(cat "$batch_file" | tr '\n' ' ' | sed 's/ $//')
-    branch_count=$(cat "$batch_file" | grep -c '.' || true)
-
-    # Skip empty batch files (can occur due to trailing newlines in branch list)
-    if [[ ${branch_count} -eq 0 ]]; then
-        rm "$batch_file"
-        continue
-    fi
-
-    # Create JSON object for this batch
-    batch_json=$(jq -n \
-        --arg batch "$batch_num" \
-        --arg branches "$batch_branches" \
-        --arg count "$branch_count" \
-        '{batch: $batch, branches: $branches, count: ($count | tonumber)}')
-
-    # Add to matrix
-    matrix_include=$(echo "$matrix_include" | jq --argjson item "$batch_json" '. += [$item]')
-
-    echo "Batch ${batch_num}: ${branch_count} branches"
-    batch_num=$((batch_num + 1))
-    rm "$batch_file"
-done
-
-# Output matrix for GitHub Actions (compact JSON, single line)
-matrix_json=$(jq -nc --argjson include "$matrix_include" '{include: $include}')
-echo "matrix=${matrix_json}" >> "$GITHUB_OUTPUT"
+# Delegate batch building to build-matrix
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "$branches" | "${SCRIPT_DIR}/build-matrix" --batch-size "${BATCH_SIZE}"
 
 echo ""
 echo "====== DISCOVERY COMPLETE ======"
 echo "Total branches found: ${total_branches}"
 echo "Branches after filtering: ${filtered_count}"
-echo "Total batches: ${num_batches}"
-echo "Matrix JSON (pretty):"
-echo "$matrix_json" | jq .

--- a/discover-branches
+++ b/discover-branches
@@ -128,10 +128,16 @@ echo "Will create ${num_batches} batches of up to ${BATCH_SIZE} branches each"
 matrix_include='[]'
 batch_num=0
 
-echo "$branches" | split -l "${BATCH_SIZE}" - batch_
+printf '%s' "$branches" | split -l "${BATCH_SIZE}" - batch_
 for batch_file in batch_*; do
     batch_branches=$(cat "$batch_file" | tr '\n' ' ' | sed 's/ $//')
-    branch_count=$(cat "$batch_file" | wc -l | tr -d ' ')
+    branch_count=$(cat "$batch_file" | grep -c '.' || true)
+
+    # Skip empty batch files (can occur due to trailing newlines in branch list)
+    if [[ ${branch_count} -eq 0 ]]; then
+        rm "$batch_file"
+        continue
+    fi
 
     # Create JSON object for this batch
     batch_json=$(jq -n \

--- a/tests/test-build-matrix.sh
+++ b/tests/test-build-matrix.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+#
+# test-build-matrix.sh: Manual test runner for build-matrix.
+#
+# Tests the batch-building logic with various branch counts, including the
+# exact edge case (count exactly divisible by batch size) that caused the
+# Feb 2026 production failure.
+#
+# Usage:
+#   ./tests/test-build-matrix.sh
+#   ./tests/test-build-matrix.sh --verbose   # print full matrix JSON for each case
+#
+# Requirements: jq, bash 4+
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_MATRIX="${SCRIPT_DIR}/../build-matrix"
+
+VERBOSE=false
+if [[ "${1}" == "--verbose" ]]; then
+    VERBOSE=true
+fi
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $*"; ((PASS+=1)); }
+fail() { echo "  FAIL: $*"; ((FAIL+=1)); }
+
+# Generate N unique branch names
+gen_branches() {
+    local n="$1"
+    local i
+    for ((i=1; i<=n; i++)); do
+        echo "feature/branch-${i}"
+    done
+}
+
+# Run build-matrix with the given branch list and batch size.
+# Prints the compact matrix JSON on stdout; all build-matrix output goes to stderr.
+run_build_matrix() {
+    local branch_list="$1"
+    local batch_size="${2:-100}"
+    local tmpout
+    tmpout=$(mktemp)
+
+    # GITHUB_OUTPUT must be exported before the pipeline so the subprocess
+    # (build-matrix) inherits it. Inline assignment before a pipeline only
+    # applies to the first command in the pipeline, not to subsequent ones.
+    export GITHUB_OUTPUT="$tmpout"
+    printf '%s\n' "$branch_list" \
+        | "$BUILD_MATRIX" --batch-size "$batch_size" >/dev/null 2>&1 || {
+            echo ""   # return empty string on failure
+            rm -f "$tmpout"
+            return 1
+        }
+    unset GITHUB_OUTPUT
+
+    # Extract the matrix JSON value from "matrix=<json>"
+    local json
+    json=$(grep '^matrix=' "$tmpout" | head -1 | sed 's/^matrix=//')
+    rm -f "$tmpout"
+    printf '%s' "$json"
+}
+
+assert_batch_count() {
+    local label="$1"
+    local json="$2"
+    local expected_batches="$3"
+    local actual_batches
+    actual_batches=$(echo "$json" | jq '.include | length')
+    if [[ "$actual_batches" -eq "$expected_batches" ]]; then
+        pass "$label — expected ${expected_batches} batches, got ${actual_batches}"
+    else
+        fail "$label — expected ${expected_batches} batches, got ${actual_batches}"
+    fi
+}
+
+assert_total_branch_count() {
+    local label="$1"
+    local json="$2"
+    local expected_total="$3"
+    local actual_total
+    actual_total=$(echo "$json" | jq '[.include[].count] | add // 0')
+    if [[ "$actual_total" -eq "$expected_total" ]]; then
+        pass "$label — expected total branch count ${expected_total}, got ${actual_total}"
+    else
+        fail "$label — expected total branch count ${expected_total}, got ${actual_total}"
+    fi
+}
+
+assert_no_empty_batches() {
+    local label="$1"
+    local json="$2"
+    local empty_batches
+    empty_batches=$(echo "$json" | jq '[.include[] | select(.count == 0 or .branches == "")] | length')
+    if [[ "$empty_batches" -eq 0 ]]; then
+        pass "$label — no empty batches"
+    else
+        fail "$label — found ${empty_batches} empty batch(es)"
+    fi
+}
+
+assert_max_batch_size() {
+    local label="$1"
+    local json="$2"
+    local batch_size="$3"
+    local oversized
+    oversized=$(echo "$json" | jq --argjson max "$batch_size" '[.include[] | select(.count > $max)] | length')
+    if [[ "$oversized" -eq 0 ]]; then
+        pass "$label — all batches are within batch size ${batch_size}"
+    else
+        fail "$label — found ${oversized} batch(es) exceeding batch size ${batch_size}"
+    fi
+}
+
+assert_branch_count_matches_list() {
+    local label="$1"
+    local json="$2"
+    local expected_total="$3"
+    # Verify that count fields actually match the number of branch names in each batch
+    local mismatched
+    mismatched=$(echo "$json" | jq '
+        [ .include[] |
+          . as $b |
+          ($b.branches | split(" ") | length) as $actual |
+          select($actual != $b.count)
+        ] | length
+    ')
+    if [[ "$mismatched" -eq 0 ]]; then
+        pass "$label — count fields match actual branch name counts"
+    else
+        fail "$label — ${mismatched} batch(es) have count fields that don't match branch name counts"
+    fi
+}
+
+run_case() {
+    local label="$1"
+    local branch_count="$2"
+    local batch_size="${3:-100}"
+
+    echo ""
+    echo "── ${label} (${branch_count} branches, batch size ${batch_size}) ──"
+
+    local branches
+    branches=$(gen_branches "$branch_count")
+
+    local json
+    json=$(run_build_matrix "$branches" "$batch_size")
+
+    if [[ -z "$json" ]]; then
+        fail "$label — build-matrix produced no output"
+        return
+    fi
+
+    local expected_batches=$(( (branch_count + batch_size - 1) / batch_size ))
+    [[ "$branch_count" -eq 0 ]] && expected_batches=0
+
+    assert_batch_count           "$label" "$json" "$expected_batches"
+    assert_total_branch_count    "$label" "$json" "$branch_count"
+    assert_no_empty_batches      "$label" "$json"
+    assert_max_batch_size        "$label" "$json" "$batch_size"
+    assert_branch_count_matches_list "$label" "$json" "$branch_count"
+
+    if $VERBOSE; then
+        echo "  Matrix JSON:"
+        echo "$json" | jq .
+    fi
+}
+
+# ── test cases ────────────────────────────────────────────────────────────────
+
+echo "========================================"
+echo " build-matrix test suite"
+echo "========================================"
+
+# Zero branches — should produce empty matrix
+run_case "zero branches" 0
+
+# Small non-divisible count
+run_case "10 branches" 10
+
+# Exactly one full batch
+run_case "100 branches (exact)" 100
+
+# One full batch plus a small remainder
+run_case "101 branches" 101
+
+# The exact failure scenario from Feb 2026: 300 branches, batch size 100
+run_case "300 branches (exact multiple — original bug)" 300
+
+# Large non-divisible count
+run_case "684 branches" 684
+
+# Non-default batch size
+run_case "50 branches, batch size 10" 50 10
+run_case "100 branches, batch size 10 (exact multiple)" 100 10
+
+# Single branch
+run_case "1 branch" 1
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "========================================"
+echo " Results: ${PASS} passed, ${FAIL} failed"
+echo "========================================"
+
+if [[ "${FAIL}" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Problem

When the number of branches to process is an exact multiple of the batch size (e.g. 300 branches with batch size 100), the discovery step produced a ghost extra batch with `branches: ""` and `count: 1`.

The root cause was in `discover-branches`: the `$filtered_branches` variable already ends with a trailing newline from how branches are appended. Piping it through `echo` added a second newline, so `split -l 100` saw a blank line at the end of its input and created an extra file containing only that blank line.

That ghost batch then ran `delete-old-branches` with no `BRANCH_LIST`, fell into legacy mode, and called `git ls-remote` against a git repo with no remote configured:

```
Processing all branches (legacy mode)...
fatal: No remote configured to list refs from.
```

## Fix

Two changes to address the root cause and add a defensive guard:

1. **`printf '%s'` instead of `echo`** — `printf '%s'` does not append an extra newline, so `split` receives exactly the right number of lines with no trailing blank.
2. **Empty batch guard** — skip any `batch_*` file where `grep -c '.'` returns 0, as a safety net against future edge cases.

## Testability

The batch-building logic has been extracted from `discover-branches` into a standalone `build-matrix` script that reads a branch list from stdin and emits the matrix JSON. This separates the pure batching logic from the network calls (`git ls-remote`, `gh api`), making it directly testable without any GitHub credentials or connectivity.

A test suite has been added at `tests/test-build-matrix.sh`:

```bash
# Run all tests (45 assertions across 9 cases)
./tests/test-build-matrix.sh

# Show full matrix JSON output per case
./tests/test-build-matrix.sh --verbose
```

Test cases cover: 0 branches, 1 branch, 10 branches, 100 (exact multiple), 101, 300 (the original failure scenario), 684, and custom batch sizes. Each case asserts correct batch count, total branch count, no empty batches, no oversized batches, and that `count` fields match actual branch name counts.

You can also test `build-matrix` directly:

```bash
cat my-branches.txt | ./build-matrix --batch-size 50
```