### PR TITLE
fix: copy build-matrix into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN apk add --no-cache bash ca-certificates git github-cli jq coreutils
 
 COPY delete-old-branches /usr/bin/delete-old-branches
 COPY discover-branches /usr/bin/discover-branches
+COPY build-matrix /usr/bin/build-matrix
 
 ENTRYPOINT ["/usr/bin/delete-old-branches"]


### PR DESCRIPTION
## Problem

The `discover` job in the Cron / Cleanup / Delete Stale Branches workflow was failing with:

```
====== FILTERING SUMMARY ======
Total branches: 799
Filtered out:
  - Default branches: 1
  - Regex-protected branches: 2
  - Branches with open PRs: 487
Remaining branches to process: 309
/usr/bin/discover-branches: line 111: /usr/bin/build-matrix: No such file or directory
```

Ref: https://github.com/betterup/betterup-monolith/actions/runs/22380207380/job/64778993539

## Root Cause

`discover-branches` locates `build-matrix` relative to itself using `SCRIPT_DIR`:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
echo "$branches" | "${SCRIPT_DIR}/build-matrix" --batch-size "${BATCH_SIZE}"
```

Inside the Docker container the entrypoint is `/usr/bin/discover-branches`, so `SCRIPT_DIR` resolves to `/usr/bin`. However, the `Dockerfile` only copied `delete-old-branches` and `discover-branches` — `build-matrix` was never added to the image, causing the `No such file or directory` error at runtime.

## Fix

Add `COPY build-matrix /usr/bin/build-matrix` to the `Dockerfile` so all three scripts land in `/usr/bin` alongside each other.